### PR TITLE
Scriptmeta

### DIFF
--- a/lib/nsfunc/application-navigation-api/resolve-url.js
+++ b/lib/nsfunc/application-navigation-api/resolve-url.js
@@ -21,8 +21,9 @@ exports.nlapiResolveURL = (type, identifier, id, displayMode) => {
     let db = global.$db;
     if (~['suitelet', 'restlet'].indexOf(type)) {
         if (!identifier) throw nlapiCreateError('SSS_IDENTFIER_ARG_REQ');
+        if (!id) throw nlapiCreateError('INVALID_ID');
         let scripts = db('__scripts'),
-            script = scripts.chain().where({name: identifier}).value();
+            script = scripts.chain().where({name: identifier, deploymentname : id}).value();
         if (!script || script.length === 0) {
             throw nlapiCreateError('SSS_INVALID_IDENTFIER_ARG');
         }

--- a/lib/nsfunc/application-navigation-api/resolve-url.js
+++ b/lib/nsfunc/application-navigation-api/resolve-url.js
@@ -20,8 +20,10 @@ exports.nlapiResolveURL = (type, identifier, id, displayMode) => {
 
     let db = global.$db;
     if (~['suitelet', 'restlet'].indexOf(type)) {
-        if (!identifier) throw nlapiCreateError('SSS_IDENTFIER_ARG_REQ');
+        if (!identifier) throw nlapiCreateError('SSS_MISSING_REQD_ARGUMENT');
         if (!id) throw nlapiCreateError('INVALID_ID');
+        if (!isNaN(Number(id))) throw Error('Number argument on nlapiResolveURL 3rd parameter with 1st' +
+            ' parameter=suitelet|restlet not suported.');
         let scripts = db('__scripts'),
             script = scripts.chain().where({name: identifier, deploymentname : id}).value();
         if (!script || script.length === 0) {

--- a/src/database.js
+++ b/src/database.js
@@ -60,6 +60,8 @@ exports.load = (cb) => {
  *    id: number,
  *    name: string
  *    type: string,
+ *    [deploymentname] : String
+ *    [deploymentid] : number,
  *    files: [string],
  *    params: {}
  * }}
@@ -76,10 +78,12 @@ exports.createSuiteScript = (data) => {
 
     let scripts = $db('__scripts');
     if (!data.id) data.id = (scripts.size() + 1);
+    data.deploymentid = data.deploymentid || 1;
+    data.deploymentname = data.deploymentname || 'customdeploy' + data.name.substr( 'customscript'.length ),
 
     data.uri = URI[data.type]; // only suitelet and restlet
     if (data.uri) {
-        data.url = `http://localhost:${srvconf.port}${data.uri}?script=${data.id}`;
+        data.url = `http://localhost:${srvconf.port}${data.uri}?script=${data.id}&deploy=${data.deploymentid}`;
     }
 
     // create script in other context

--- a/src/suite-script/ss-restlet.js
+++ b/src/suite-script/ss-restlet.js
@@ -9,6 +9,8 @@ var database = require('../database'),
  *
  * @param opt {{
  *    name: String,
+ *    [deploymentname] : String,
+ *    [deploymentid] : Number,
  *    files: [String],
  *    params: Object,
  *    funcs: {
@@ -37,6 +39,8 @@ module.exports = (opt, cb) => {
     let context = database.createSuiteScript({
         type: 'restlet',
         name: opt.name,
+        deploymentname : opt.deploymentname,
+        deploymentid : opt.deploymentid,
         funcs: opt.funcs,
         files: opt.files,
         params: opt.params

--- a/src/suite-script/ss-suitelet.js
+++ b/src/suite-script/ss-suitelet.js
@@ -8,6 +8,8 @@ var database = require('../database'),
  *
  * @param opt {{
  *    name: String,
+ *    [deploymentname] : String,
+ *    [deploymentid] : Number,
  *    files: [String],
  *    params: Object,
  *    func: String
@@ -26,6 +28,8 @@ module.exports = (opt, cb) => {
     let context = database.createSuiteScript({
         type: 'suitelet',
         name: opt.name,
+        deploymentname : opt.deploymentname,
+        deploymentid : opt.deploymentid,
         func: opt.func,
         files: opt.files,
         params: opt.params

--- a/test/application-navigation-api/appication-navigation-api-test.js
+++ b/test/application-navigation-api/appication-navigation-api-test.js
@@ -12,6 +12,7 @@ describe('<Unit Test - Netsuite Application Navigation API>', function () {
     let ropts = {
             // RESTlet Config
             name: 'customscript_add_restlet',
+            deploymentname : 'customdeploy_add_restlet' ,
             files: [
                 __dirname + '/../_input-files/scripts/fake-restlet.js'
             ],
@@ -26,6 +27,7 @@ describe('<Unit Test - Netsuite Application Navigation API>', function () {
         sopts = {
             // Suitelet Config
             name: 'customscript_add_suitelet',
+            deploymentname : 'customdeploy_add_suitelet' ,
             files: [
                 __dirname + '/../_input-files/scripts/fake-suitelet.js'
             ],
@@ -44,13 +46,13 @@ describe('<Unit Test - Netsuite Application Navigation API>', function () {
     });
     describe('SuiteScript API - nlapiResolveURL:', function () {
         it('resolve get internal URL from RESTlet', function (done) {
-            let url = nlapiResolveURL('RESTLET', ropts.name);
+            let url = nlapiResolveURL('RESTLET', ropts.name, ropts.deploymentname);
             should(url).be.ok();
             return done();
         });
 
         it('resolve get internal URL from Suitelet', function (done) {
-            let url = nlapiResolveURL('SUITELET', sopts.name);
+            let url = nlapiResolveURL('SUITELET', sopts.name, sopts.deploymentname);
             should(url).be.ok();
             return done();
         });
@@ -79,12 +81,21 @@ describe('<Unit Test - Netsuite Application Navigation API>', function () {
 
         it('resolve identifier not found', function (done) {
             try {
-                let o = nlapiResolveURL('SUITELET', 'customscript_japopop');
+                let o = nlapiResolveURL('SUITELET', 'customscript_japopop','customdeploy_japopop');
                 should(o).have.instanceOf(String);
                 return done('missing id: '+o.getId());
             } catch (e) {
                 should(e).have.property('code', 'SSS_INVALID_IDENTFIER_ARG');
                 return done();
+            }
+        });
+
+        it('resolve deployment id not found' , function() {
+            try {
+                nlapiResolveURL('RESTLET', ropts.name);
+            } catch(e) {
+                should(e).have.property('code', 'INVALID_ID');
+                return done()
             }
         });
 
@@ -114,7 +125,7 @@ describe('<Unit Test - Netsuite Application Navigation API>', function () {
 
     describe('SuiteScript API - nlapiRequestURL:', function () {
         it('request only restlet URL', function (done) {
-            let url = nlapiResolveURL('RESTLET', ropts.name);
+            let url = nlapiResolveURL('RESTLET', ropts.name, ropts.deploymentname);
             should(url).be.ok();
             let res = nlapiRequestURL(url+'&fake=12');
             should(res).be.ok();
@@ -124,7 +135,7 @@ describe('<Unit Test - Netsuite Application Navigation API>', function () {
         });
 
         it('request only suitelet URL', function (done) {
-            let url = nlapiResolveURL('SUITELET', sopts.name);
+            let url = nlapiResolveURL('SUITELET', sopts.name, sopts.deploymentname);
             should(url).be.ok();
             let res = nlapiRequestURL(url+'&fake=22');
             should(res).be.ok();
@@ -134,7 +145,7 @@ describe('<Unit Test - Netsuite Application Navigation API>', function () {
         });
 
         it('request restlet URL method POST', function (done) {
-            let url = nlapiResolveURL('RESTLET', ropts.name);
+            let url = nlapiResolveURL('RESTLET', ropts.name, ropts.deploymentname);
             should(url).be.ok();
             let res = nlapiRequestURL(url, {fake: 12}, null, 'POST');
             should(res).be.ok();

--- a/test/application-navigation-api/appication-navigation-api-test.js
+++ b/test/application-navigation-api/appication-navigation-api-test.js
@@ -144,6 +144,7 @@ describe('<Unit Test - Netsuite Application Navigation API>', function () {
         });
     });
 
+
     after(function (done) {
         nsmockup.destroy(done);
     });

--- a/test/application-navigation-api/appication-navigation-api-test.js
+++ b/test/application-navigation-api/appication-navigation-api-test.js
@@ -74,7 +74,7 @@ describe('<Unit Test - Netsuite Application Navigation API>', function () {
                 should(o).have.instanceOf(String);
                 return done('missing id: '+o.getId());
             } catch (e) {
-                should(e).have.property('code', 'SSS_IDENTFIER_ARG_REQ');
+                should(e).have.property('code', 'SSS_MISSING_REQD_ARGUMENT');
                 return done();
             }
         });
@@ -90,12 +90,12 @@ describe('<Unit Test - Netsuite Application Navigation API>', function () {
             }
         });
 
-        it('resolve deployment id not found' , function() {
+        it('resolve deployment id not found' , function(done) {
             try {
                 nlapiResolveURL('RESTLET', ropts.name);
             } catch(e) {
                 should(e).have.property('code', 'INVALID_ID');
-                return done()
+                done()
             }
         });
 

--- a/test/create-restlet-test.js
+++ b/test/create-restlet-test.js
@@ -15,6 +15,7 @@ describe('<Unit Test - Netsuite Create Restlet>', function () {
         it('create restlet', function (done) {
             let opts = {
                 name: 'customscript_add_restlet',
+                deploymentname: 'customdeploy_add_restlet',
                 files: [
                     __dirname + '/_input-files/scripts/fake-restlet.js'
                 ],
@@ -28,7 +29,7 @@ describe('<Unit Test - Netsuite Create Restlet>', function () {
             nsmockup.createRESTlet(opts, (ctx) => {
                 should(ctx.FakeRestlet).be.ok();
 
-                let url = nlapiResolveURL('RESTLET', opts.name);
+                let url = nlapiResolveURL('RESTLET', opts.name, opts.deploymentname);
                 should(url).be.ok();
 
                 let res = nlapiRequestURL(url + '&fake=12', null, null, 'GET');


### PR DESCRIPTION
- `nlapiResolveURL` called with **suitelet** or **restlet** requires the deploymentid as the third parameter. It throws `INVALID_ID` if deploymentid null or not found.
- Add the deployment id to the script store. For now take a nsmockup script record as a netsuite deployment record.
- The deployment id is still optional when declaring a script on nsmockup. Initializing with a null deploy id populates it with a default name based on the script id.
- The third parameter also accepts a number on NS. Delay support for this (add error message).
- 2nd parameter missing throws `SSS_MISSING_REQD_ARGUMENT` in practice
