### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/ctx-utils/sublist.js
+++ b/lib/ctx-utils/sublist.js
@@ -1,5 +1,5 @@
 'use strict';
-var uuid = require('node-uuid'),
+var uuid = require('uuid'),
     vmSim = require('../../src/vm-sim'),
     $metadata = require('../db-utils/metadata');
 

--- a/lib/nsobj/record.js
+++ b/lib/nsobj/record.js
@@ -1,7 +1,7 @@
 'use strict';
 var $metadata = require('../db-utils/metadata'),
     $sublist = require('../ctx-utils/sublist'),
-    uuid = require('node-uuid');
+    uuid = require('uuid');
 
 /**
  * Return a new instance of nlobjRecord used for accessing and manipulating record objects.

--- a/nsapi.js
+++ b/nsapi.js
@@ -2,7 +2,7 @@
 var vmSim = require('./src/vm-sim');
 
 // load node-uuid before create window property in global
-require('node-uuid');
+require('uuid');
 
 var moment = require('moment');
 moment.createFromInputFallback = function(config) {

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "minimatch": "3.0.0",
     "moment": "2.11.2",
     "morgan": "1.6.1",
-    "node-uuid": "1.4.7",
     "ns-formula-parse": "0.3.0",
     "sync-request": "3.0.0",
+    "uuid": "^3.0.0",
     "xmldom": "0.1.22",
     "xpath": "0.0.21"
   },

--- a/src/init.js
+++ b/src/init.js
@@ -5,7 +5,7 @@ var server = require('./server'),
     path = require('path'),
     glob = require('glob'),
     _ = require('lodash'),
-    uuid = require('node-uuid');
+    uuid = require('uuid');
 
 /**
  * Alternative a cache created by 'require(path)'.


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.